### PR TITLE
When called with no args, use last jumped tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ If you want to remap `g<C-]>` and `g]`, copy the following lines into your vimrc
     nnoremap g<C-]> :<C-u>Unite -immediately tselect:<C-r>=expand('<cword>')<CR><CR>
     nnoremap g] :<C-u>Unite tselect:<C-r>=expand('<cword>')<CR><CR>
 
+To make a command that behaves like `:tselect`:
+
+    command! -nargs=* Tselect Unite tselect:<args>

--- a/autoload/unite/sources/tselect.vim
+++ b/autoload/unite/sources/tselect.vim
@@ -71,10 +71,22 @@ endfunction
 
 function! s:source.gather_candidates(args, context)
 	let l:result = []
+	let l:expr = ''
 	if empty(a:args)
-		let l:expr = '^' . expand("<cword>") . '$'
+		try
+			" Extract the last jumped tag to behave like :tselect.
+			let l:expr = execute('tags')->split('\n')[-2]->split(' ', 0)[3]
+		catch
+			" Ignore any errors and we'll fall back to cword below.
+		endtry
 	else
 		let l:expr = get(a:args, 0, '')
+	endif
+
+	" If we still have nothing, use the cursor. This seems more helpful than
+	" :tselect's error about the tag stack being empty.
+	if empty(l:expr)
+		let l:expr = '^' . expand("<cword>") . '$'
 	endif
 
 	let l:taglist = taglist(escape(l:expr, '~'))


### PR DESCRIPTION
Change `:Unity tselect` to behave like `:tselect`. This allows you to
use this command as a drop-in replacement for tselect:

  command! -nargs=* Tselect Unite tselect:<args>

The differences I'm aware of are unite's filtering and using cword
instead of an error message if tag stack is empty. And unite doesn't
push the current location onto the tagstack.